### PR TITLE
Fix errors in MUI components

### DIFF
--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTheme } from '@mui/material/styles';
 
 import { grey } from '@mui/material/colors';
-import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { TextareaAutosize } from '@mui/base/TextareaAutosize';
 import Box from '@mui/material/Box';
 import { Grid, Typography } from '@mui/material';
 

--- a/src/containers/NotFound.tsx
+++ b/src/containers/NotFound.tsx
@@ -1,4 +1,5 @@
-import Box from '@mui/material/Box';
+import { Box } from '@chakra-ui/react';
+
 export const NotFound = () => {
     return (
         <Box>


### PR DESCRIPTION
This PR fixes bugs in the following MUI components

1. `TextareaAutosize`: no default export is allowed. Change default export to named export
2. `Box` component is giving `createTheme_default` not found error. Replace MUI `Box` with Chakra `Box` component
