### PR TITLE
[OM: 6033]: Hunar Connect - Languages when not mapped on Job Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/src/components/callAutomation/AddAiCallLanguageModal.tsx
+++ b/src/components/callAutomation/AddAiCallLanguageModal.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+
+import {
+    Button,
+    FormControl,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    Text,
+    Box
+} from '@chakra-ui/react';
+import { SelectField, HelperText } from '@components/common';
+
+import { SettingsContext } from 'contexts';
+import { useValidationHelper } from 'hooks';
+import { useToast } from 'hooks/useToast';
+
+import type { OptionsProps } from 'interfaces';
+import { ErrorMsg } from 'utils';
+import { CallAutomationEditForm } from './CallAutomationEditForm';
+
+interface AddAiCallLanguageModalProps {
+    isOpen: boolean;
+    defaultLanguage: string;
+    jobQueriesCount?: number;
+    setDefaultLanguage: React.Dispatch<
+        React.SetStateAction<CallAutomationEditForm>
+    >;
+    handleCloseClick: VoidFunction;
+}
+
+export const AddAiCallLanguageModal = ({
+    isOpen,
+    defaultLanguage,
+    jobQueriesCount = 0,
+    handleCloseClick,
+    setDefaultLanguage
+}: AddAiCallLanguageModalProps) => {
+    const {
+        formFields: { callLanguage }
+    } = React.useContext(SettingsContext);
+
+    const { hasFormFieldError } = useValidationHelper();
+    const { showError } = useToast();
+
+    const callLanguageOptions: OptionsProps = React.useMemo(() => {
+        return callLanguage ?? [];
+    }, [callLanguage]);
+
+    const [languageError, setLanguageError] = React.useState<boolean>(false);
+
+    const onLanguageChange = React.useCallback(
+        ({ target: { name, value } }: React.ChangeEvent<HTMLSelectElement>) => {
+            setDefaultLanguage(prevForm => ({
+                ...prevForm,
+                defaultLanguage: value
+            }));
+            setLanguageError(
+                hasFormFieldError({ fieldName: name, fieldValue: value })
+            );
+        },
+        [hasFormFieldError, setDefaultLanguage]
+    );
+
+    const onSubmit = React.useCallback(() => {
+        if (!defaultLanguage) {
+            setLanguageError(true);
+            showError({
+                title: 'Error',
+                description: 'Please select a language'
+            });
+            return;
+        }
+
+        handleCloseClick();
+    }, [defaultLanguage, handleCloseClick, showError]);
+
+    return (
+        <Modal
+            size="lg"
+            isOpen={isOpen}
+            onClose={handleCloseClick}
+            closeOnEsc={false}
+            closeOnOverlayClick={false}
+        >
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>{`Choose Default Language`}</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody paddingY={6}>
+                    <Box mb={6}>
+                        <Text
+                            display="flex"
+                            marginBottom={0.5}
+                            fontSize="md"
+                            fontWeight={600}
+                        >
+                            {`This company has ${jobQueriesCount} without AI calling language!`}
+                        </Text>
+                        <Text fontSize="sm">
+                            To enable automated calling, please select a default
+                            language for all JQs with missing language.
+                        </Text>
+                    </Box>
+                    <FormControl>
+                        <SelectField
+                            label=""
+                            name="defaultLanguage"
+                            placeholder="Choose Language"
+                            options={callLanguageOptions}
+                            value={defaultLanguage}
+                            onChange={onLanguageChange}
+                            isInvalid={languageError}
+                            helperText={
+                                <HelperText
+                                    hasError={languageError}
+                                    errorMsg={ErrorMsg.required()}
+                                />
+                            }
+                        />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                    <Button mr={3} onClick={handleCloseClick}>
+                        {`CANCEL`}
+                    </Button>
+                    <Button colorScheme="blue" onClick={onSubmit}>
+                        {`SAVE LANGUAGE`}
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};

--- a/src/components/callAutomation/AddAiCallLanguageModal.tsx
+++ b/src/components/callAutomation/AddAiCallLanguageModal.tsx
@@ -99,7 +99,7 @@ export const AddAiCallLanguageModal = ({
                             fontSize="md"
                             fontWeight={600}
                         >
-                            {`This company has ${jobQueriesCount} without AI calling language!`}
+                            {`This company has ${jobQueriesCount} JQs without AI calling language!`}
                         </Text>
                         <Text fontSize="sm">
                             To enable automated calling, please select a default

--- a/src/components/callAutomation/CallAutomationEditForm.tsx
+++ b/src/components/callAutomation/CallAutomationEditForm.tsx
@@ -77,7 +77,9 @@ export const CallAutomationEditForm = () => {
 
     const { data: companiesResponse, isLoading: isCompaniesLoading } =
         useGetCompanies();
-    const { companyIdOptions } = useCompanyHelper(companiesResponse?.data);
+    const { companyIdOptions, companyMap } = useCompanyHelper(
+        companiesResponse?.data
+    );
 
     const { data: voicePersonas, isLoading: isVoicePersonasLoading } =
         useSearchVoicePersona({
@@ -101,7 +103,8 @@ export const CallAutomationEditForm = () => {
                 companyId: form.companyId,
                 isCallAutomationEnabled:
                     prevForm?.isCallAutomationEnabled || data.enabled,
-                defaultLanguage: prevForm.defaultLanguage,
+                defaultLanguage:
+                    prevForm.defaultLanguage || data.defaultLanguage,
                 aiPersonaId: (prevForm?.aiPersonaId || data.persona?.id) ?? '',
                 selectedProviderId:
                     (prevForm?.selectedProviderId ||
@@ -133,6 +136,14 @@ export const CallAutomationEditForm = () => {
         form.isCallAutomationEnabled,
         isVoiceConfigLoading
     ]);
+
+    const jobQueriesWithoutLanguageCount = React.useMemo(() => {
+        if (!form.companyId || !companyMap) {
+            return 0;
+        }
+        const selectedCompany = companyMap[form.companyId];
+        return selectedCompany?.jobQueriesWithoutLanguageCount ?? 0;
+    }, [form.companyId, companyMap]);
 
     const updateFieldError = (fieldName: string, fieldValue: string) => {
         setFormErrors(prevFormErrors => ({
@@ -336,7 +347,7 @@ export const CallAutomationEditForm = () => {
                     )}
                     {isAddAiCallLanguageModalVisible && (
                         <AddAiCallLanguageModal
-                            jobQueriesCount={0}
+                            jobQueriesCount={jobQueriesWithoutLanguageCount}
                             defaultLanguage={form.defaultLanguage}
                             isOpen={isAddAiCallLanguageModalVisible}
                             handleCloseClick={handleCloseAiCallLanguageModal}

--- a/src/components/callAutomation/CallAutomationEditForm.tsx
+++ b/src/components/callAutomation/CallAutomationEditForm.tsx
@@ -172,7 +172,7 @@ export const CallAutomationEditForm = () => {
         const isCallAutomationEnabled = e.target.checked;
         setForm(prevForm => ({ ...prevForm, isCallAutomationEnabled }));
 
-        if (isCallAutomationEnabled) {
+        if (isCallAutomationEnabled && jobQueriesWithoutLanguageCount > 0) {
             setIsAddAiCallLanguageModalVisible(true);
         }
     };

--- a/src/components/callAutomation/CallAutomationEditForm.tsx
+++ b/src/components/callAutomation/CallAutomationEditForm.tsx
@@ -9,7 +9,7 @@ import {
     HelperText
 } from '@components/common';
 import {
-    AddAiCallLanguageModal,
+    CallAutomationLanguageSelectModal,
     AddVoiceProviderConfigModal,
     SelectVoiceProviderRadioGroup
 } from '@components/callAutomation';
@@ -346,7 +346,7 @@ export const CallAutomationEditForm = () => {
                         />
                     )}
                     {isAddAiCallLanguageModalVisible && (
-                        <AddAiCallLanguageModal
+                        <CallAutomationLanguageSelectModal
                             jobQueriesCount={jobQueriesWithoutLanguageCount}
                             defaultLanguage={form.defaultLanguage}
                             isOpen={isAddAiCallLanguageModalVisible}

--- a/src/components/callAutomation/CallAutomationEditForm.tsx
+++ b/src/components/callAutomation/CallAutomationEditForm.tsx
@@ -9,6 +9,7 @@ import {
     HelperText
 } from '@components/common';
 import {
+    AddAiCallLanguageModal,
     AddVoiceProviderConfigModal,
     SelectVoiceProviderRadioGroup
 } from '@components/callAutomation';
@@ -24,9 +25,10 @@ import { useToast } from 'hooks/useToast';
 import type { OptionsProps } from 'interfaces';
 import { ErrorMsg } from 'utils';
 
-interface CallAutomationEditForm {
+export interface CallAutomationEditForm {
     companyId: string;
     isCallAutomationEnabled: boolean;
+    defaultLanguage: string;
     aiPersonaId: string;
     selectedProviderId?: string;
 }
@@ -34,6 +36,7 @@ interface CallAutomationEditForm {
 const callAutomationFormInitialValues: CallAutomationEditForm = {
     companyId: '',
     isCallAutomationEnabled: false,
+    defaultLanguage: '',
     aiPersonaId: '',
     selectedProviderId: ''
 };
@@ -67,6 +70,10 @@ export const CallAutomationEditForm = () => {
     });
     const [isAddVoiceProviderModalVisible, setIsAddVoiceProviderModalVisible] =
         React.useState(false);
+    const [
+        isAddAiCallLanguageModalVisible,
+        setIsAddAiCallLanguageModalVisible
+    ] = React.useState(false);
 
     const { data: companiesResponse, isLoading: isCompaniesLoading } =
         useGetCompanies();
@@ -94,6 +101,7 @@ export const CallAutomationEditForm = () => {
                 companyId: form.companyId,
                 isCallAutomationEnabled:
                     prevForm?.isCallAutomationEnabled || data.enabled,
+                defaultLanguage: prevForm.defaultLanguage,
                 aiPersonaId: (prevForm?.aiPersonaId || data.persona?.id) ?? '',
                 selectedProviderId:
                     (prevForm?.selectedProviderId ||
@@ -152,6 +160,10 @@ export const CallAutomationEditForm = () => {
     ) => {
         const isCallAutomationEnabled = e.target.checked;
         setForm(prevForm => ({ ...prevForm, isCallAutomationEnabled }));
+
+        if (isCallAutomationEnabled) {
+            setIsAddAiCallLanguageModalVisible(true);
+        }
     };
 
     const onSelectedProviderChange = (selectedProviderId: string) => {
@@ -172,6 +184,7 @@ export const CallAutomationEditForm = () => {
                 params: { companyId: form.companyId },
                 body: {
                     enabled: form.isCallAutomationEnabled,
+                    defaultLanguage: form.defaultLanguage,
                     ...callAutomationConfig
                 }
             },
@@ -212,6 +225,16 @@ export const CallAutomationEditForm = () => {
 
         onUpdateVoiceConfiguration();
     };
+
+    const handleCloseAiCallLanguageModal = React.useCallback(() => {
+        if (!form.defaultLanguage) {
+            setForm(prevForm => ({
+                ...prevForm,
+                isCallAutomationEnabled: false
+            }));
+        }
+        setIsAddAiCallLanguageModalVisible(false);
+    }, [form.defaultLanguage]);
 
     return (
         <FormWrapper
@@ -309,6 +332,15 @@ export const CallAutomationEditForm = () => {
                             refetchVoiceConfiguraiton={
                                 refetchVoiceConfiguraiton
                             }
+                        />
+                    )}
+                    {isAddAiCallLanguageModalVisible && (
+                        <AddAiCallLanguageModal
+                            jobQueriesCount={0}
+                            defaultLanguage={form.defaultLanguage}
+                            isOpen={isAddAiCallLanguageModalVisible}
+                            handleCloseClick={handleCloseAiCallLanguageModal}
+                            setDefaultLanguage={setForm}
                         />
                     )}
                 </Box>

--- a/src/components/callAutomation/CallAutomationEditForm.tsx
+++ b/src/components/callAutomation/CallAutomationEditForm.tsx
@@ -195,7 +195,9 @@ export const CallAutomationEditForm = () => {
                 params: { companyId: form.companyId },
                 body: {
                     enabled: form.isCallAutomationEnabled,
-                    defaultLanguage: form.defaultLanguage,
+                    defaultLanguage: form.isCallAutomationEnabled
+                        ? form.defaultLanguage
+                        : null,
                     ...callAutomationConfig
                 }
             },

--- a/src/components/callAutomation/CallAutomationLanguageSelectModal.tsx
+++ b/src/components/callAutomation/CallAutomationLanguageSelectModal.tsx
@@ -23,7 +23,7 @@ import type { OptionsProps } from 'interfaces';
 import { ErrorMsg } from 'utils';
 import { CallAutomationEditForm } from './CallAutomationEditForm';
 
-interface AddAiCallLanguageModalProps {
+interface CallAutomationLanguageSelectModalProps {
     isOpen: boolean;
     defaultLanguage: string;
     jobQueriesCount?: number;
@@ -33,13 +33,13 @@ interface AddAiCallLanguageModalProps {
     handleCloseClick: VoidFunction;
 }
 
-export const AddAiCallLanguageModal = ({
+export const CallAutomationLanguageSelectModal = ({
     isOpen,
     defaultLanguage,
     jobQueriesCount = 0,
     handleCloseClick,
     setDefaultLanguage
-}: AddAiCallLanguageModalProps) => {
+}: CallAutomationLanguageSelectModalProps) => {
     const {
         formFields: { callLanguage }
     } = React.useContext(SettingsContext);
@@ -71,7 +71,7 @@ export const AddAiCallLanguageModal = ({
             setLanguageError(true);
             showError({
                 title: 'Error',
-                description: 'Please select a language'
+                description: 'Please select a language!'
             });
             return;
         }

--- a/src/components/callAutomation/index.tsx
+++ b/src/components/callAutomation/index.tsx
@@ -1,4 +1,4 @@
 export { CallAutomationEditForm } from './CallAutomationEditForm';
-export { AddAiCallLanguageModal } from './AddAiCallLanguageModal';
+export { CallAutomationLanguageSelectModal } from './CallAutomationLanguageSelectModal';
 export { AddVoiceProviderConfigModal } from './AddVoiceProviderConfigModal';
 export { SelectVoiceProviderRadioGroup } from './SelectVoiceProviderRadioGroup';

--- a/src/components/callAutomation/index.tsx
+++ b/src/components/callAutomation/index.tsx
@@ -1,3 +1,4 @@
 export { CallAutomationEditForm } from './CallAutomationEditForm';
+export { AddAiCallLanguageModal } from './AddAiCallLanguageModal';
 export { AddVoiceProviderConfigModal } from './AddVoiceProviderConfigModal';
 export { SelectVoiceProviderRadioGroup } from './SelectVoiceProviderRadioGroup';

--- a/src/hooks/apiHooks/voiceConfig/useUpdateVoiceConfig.tsx
+++ b/src/hooks/apiHooks/voiceConfig/useUpdateVoiceConfig.tsx
@@ -9,6 +9,7 @@ interface UseUpdateVoiceConfigProps {
     };
     body: {
         enabled: boolean;
+        defaultLanguage: string;
         personaId?: string;
         providerId?: string;
     };

--- a/src/hooks/apiHooks/voiceConfig/useUpdateVoiceConfig.tsx
+++ b/src/hooks/apiHooks/voiceConfig/useUpdateVoiceConfig.tsx
@@ -9,7 +9,7 @@ interface UseUpdateVoiceConfigProps {
     };
     body: {
         enabled: boolean;
-        defaultLanguage: string;
+        defaultLanguage: string | null;
         personaId?: string;
         providerId?: string;
     };

--- a/src/interfaces/company.interface.ts
+++ b/src/interfaces/company.interface.ts
@@ -68,6 +68,7 @@ export interface CompanyFormProps {
     rawAddress: string;
     email: string;
     mobileNumber: string;
+    jobQueriesWithoutLanguageCount: number;
     governmentIdentifiers: {
         gstin: string;
     };

--- a/src/interfaces/voiceConfig.interface.ts
+++ b/src/interfaces/voiceConfig.interface.ts
@@ -45,5 +45,6 @@ export interface VoiceConfigProps {
     companyId: string;
     enabled: boolean;
     persona: PersonaProps;
+    defaultLanguage: string;
     providers: CompanyProviderProps[];
 }


### PR DESCRIPTION
[6033](https://hunar.atlassian.net/browse/OM-6033)  | AI call language mapping 

## Description
- When a job query does not have any language mapped which can happen 
- When a JQ is old and has not completed migration after enabling AI Calling
- When a JQ was created and check interest was triggered and then AI Calling

## Added following component
- AddAiCallLanguageModal.tsx

## Related Issue
https://hunar.atlassian.net/browse/OM-6033)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other: Update in existing flow


## Figma
https://www.figma.com/design/KIAyKohiD3EqO9TNMZCR8H/Hunar-Connect-updates?node-id=1-4460&m=dev

## Deployed Link
https://ai-language-map--resplendent-unicorn-271751.netlify.app/
