### PR TITLE
Remove call upload button from Neha Select and Neha Agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/src/components/nehaAgents/NehaAgentsTableHeader.tsx
+++ b/src/components/nehaAgents/NehaAgentsTableHeader.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 import LoadingButton from '@mui/lab/LoadingButton';
-import { Button, Grid, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 
 import { SearchBar } from '@hunar.ai/hunar-design-system';
 import { Select } from '@components/common';
@@ -30,7 +29,6 @@ export const NehaAgentsTableHeader = ({
     setSearchKey
 }: AgentTableHeaderProps) => {
     const { showError, showSuccess } = useToast();
-    const [searchParams, setSearchParams] = useSearchParams();
     const { getApiErrorMsg } = useErrorHelper();
     const exportNehaSelectCalls = useExportNehaAgentCalls();
     const { data } = useGetFormFields();
@@ -39,11 +37,6 @@ export const NehaAgentsTableHeader = ({
         enabled: !!company?.value,
         params: { companyId: company?.value ?? '' }
     });
-
-    const onUploadClick = () => {
-        searchParams.set('upload', 'true');
-        setSearchParams(searchParams);
-    };
 
     const saveFile = (data: string) => {
         const file = new File([data], 'leads.csv', {
@@ -132,15 +125,6 @@ export const NehaAgentsTableHeader = ({
                     >
                         {`EXPORT`}
                     </LoadingButton>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        size="medium"
-                        disabled={!company}
-                        onClick={onUploadClick}
-                    >
-                        {`UPLOAD`}
-                    </Button>
                 </Grid>
             </Grid>
         </>

--- a/src/components/nehaSelect/NehaSelectTableHeader.tsx
+++ b/src/components/nehaSelect/NehaSelectTableHeader.tsx
@@ -1,7 +1,5 @@
-import { useSearchParams } from 'react-router-dom';
-
 import LoadingButton from '@mui/lab/LoadingButton';
-import { Button, Grid, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 
 import { SearchBar } from '@hunar.ai/hunar-design-system';
 
@@ -23,18 +21,12 @@ export const NehaSelectTableHeader = ({
     filters
 }: NehaSelectTableHeaderProps) => {
     const { showError, showSuccess } = useToast();
-    const [searchParams, setSearchParams] = useSearchParams();
     const { getApiErrorMsg } = useErrorHelper();
     const exportNehaSelectCalls = useExportNehaSelectCalls();
 
     const { data: pendingCallsData } = useGetNehaSelectPendingCalls({
         params: { companyId: NEHA_SELECT_COMPANY_ID }
     });
-
-    const onUploadClick = () => {
-        searchParams.set('upload', 'true');
-        setSearchParams(searchParams);
-    };
 
     const saveFile = (data: string) => {
         const file = new File([data], 'leads.csv', {
@@ -103,14 +95,6 @@ export const NehaSelectTableHeader = ({
                     >
                         {`EXPORT`}
                     </LoadingButton>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        size="medium"
-                        onClick={onUploadClick}
-                    >
-                        {`UPLOAD`}
-                    </Button>
                 </Grid>
             </Grid>
         </>


### PR DESCRIPTION
## Description
Disables bulk lead upload functionality across both Neha Agents and Neha Select. Neha Select and Neha Agent are deprecated. All companies are blocked from uploading leads through either service. View and export functionality is still available.

## Technical Description

### NehaAgentsTableHeader.tsx
- **Removed UPLOAD button:** Button that triggered `onUploadClick` (set `upload=true` in URL)
- **Removed upload click handler:** `onUploadClick` and `useSearchParams` hook
- **Removed unused imports:** `useSearchParams` from react-router-dom, `Button` from MUI

### NehaSelectTableHeader.tsx
- **Removed UPLOAD button:** Button that triggered `onUploadClick` (set `upload=true` in URL)
- **Removed upload click handler:** `onUploadClick` and `useSearchParams` hook
- **Removed unused imports:** `useSearchParams` from react-router-dom, `Button` from MUI

## Related Issue
NA

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Other: [Description]

## Breaking Changes
The UPLOAD button and its query-parameter behavior have been removed.

## Testing
- [x] Verified Neha Agents table header renders without UPLOAD button
- [x] Verified Neha Select table header renders without UPLOAD button

Made with [Cursor](https://cursor.com)